### PR TITLE
Drop creation of output dir

### DIFF
--- a/dump-objects
+++ b/dump-objects
@@ -61,12 +61,6 @@ if [[ "$#" -gt 0 ]]; then
   exit 1
 fi
 
-if [[ ! -d "$output_dir" ]]; then
-  mkdir -p "$output_dir"
-fi
-
-chmod ${opt_verbose:+--changes} 0700 "$output_dir"
-
 # Remove old files
 find "$output_dir" -mindepth 1 -maxdepth 1 -type f -delete
 


### PR DESCRIPTION
The output directory is supposed to already exist. This is ensured in
Dockerfile. When running in Kubernetes, it is suggested to use a
volumeMount which again will ensure existence and permissions.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
