### PR TITLE
Add "You may not request a new project via this API" to potential fetch errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 
-- …
+- Add "You may not request a new project via this API" to potential fetch errors [#9]
 
 ## [v0.1.0] - 2020-10-16
 
@@ -35,3 +35,4 @@ Release as open source code
 [#4]: https://github.com/projectsyn/k8s-object-dumper/pull/4
 [#5]: https://github.com/projectsyn/k8s-object-dumper/pull/5
 [#6]: https://github.com/projectsyn/k8s-object-dumper/pull/6
+[#9]: https://github.com/projectsyn/k8s-object-dumper/pull/9

--- a/dump-objects
+++ b/dump-objects
@@ -252,6 +252,7 @@ fetch_objects() {
       -e "^${errprefix}Unable to list {\".*\" \"v1\" \"${kind}\"}: the server could not find the requested resource\$" \
       -e "^${errprefix}Unable to list \".*/v1, Resource=${kind}\": the server could not find the requested resource\$" \
       -e "^${errprefix}the server doesn't have a resource type \"${kind}\"\$" \
+      -e "^${errprefix}You may not request a new project via this API.\$" \
       <<< "$error"
     then
       return "$EX_PROTOCOL"

--- a/known-to-fail
+++ b/known-to-fail
@@ -8,5 +8,6 @@ imagestreamimages
 imagestreamimports
 imagestreammappings
 mutations
+projectrequests
 useridentitymappings
 validations


### PR DESCRIPTION
When trying to `kubectl get projectrequests -ojson` as a ServiceAccount with cluster-reader permissions on OpenShift 4, the API server responds with the following output and error:

```
1000840000@object-dumper-test:/$ kubectl get projectrequests -o json
{
    "apiVersion": "v1",
    "items": [],
    "kind": "List",
    "metadata": {
        "resourceVersion": "",
        "selfLink": ""
    }
}
Error from server (Forbidden): You may not request a new project via this API.
```

This commit adds that error to the list of allowed errors when fetching objects.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the ./CHANGELOG.md.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
